### PR TITLE
Fixed the error handling in AbstractRequest::sendData

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,6 @@
         "ext-json": "*"
     },
     "require-dev": {
-        "omnipay/tests": "^3"
+        "omnipay/tests": "^4"
     }
 }


### PR DESCRIPTION
The code asumes `$response` is always defined but in some cases it might
not be, like a timeout from the server